### PR TITLE
Fix test.yml to allow greenkeeper

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ on:
       # PR needs to be open or not, and as such we need
       # to whitelist those branches for CI run here.
       # See also https://greenkeeper.io/faq#no-initial-pr
-      - 'greenkeeper*'
+      - 'greenkeeper**'
 
 jobs:
   test:


### PR DESCRIPTION
greenkeeper* does not match greenkeeper/initial as I was expecting.

After reviewing the doc:
https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet<Paste>

"The * wildcard matches any character, but does not match slash (/)."

This change will actually allow the greenkeeper branch to be build.

Signed-off-by: Thomas Moulard <tmoulard@amazon.com>